### PR TITLE
Added correct Bounties URL

### DIFF
--- a/warpcast.json
+++ b/warpcast.json
@@ -889,7 +889,7 @@
     },
     {
         "name": "Bounties",
-        "parent_url": "https://warpcast.com/~/channel/bounties",
+        "parent_url": "https://www.bountycaster.xyz",
         "image": "https://warpcast.com/~/channel-images/bounties.png",
         "channel_id": "bounties"
     },


### PR DESCRIPTION
Hi @manan19 - for some reason the previous PR got the Channel URL wrong. This PR sets it to the correct URL. You can see an example [here](https://vasco.wtf/cast/0x15d38530ce284f7de5b2efd786d032f736a7eca8)

Thanks again